### PR TITLE
Fix MainContext::iteration docblock

### DIFF
--- a/src/GLib/MainContext.php
+++ b/src/GLib/MainContext.php
@@ -5,7 +5,7 @@ namespace PGtk\Gtk\GLib;
 use PGtk\Gtk\Gtk;
 
 /**
- * @method iteration(bool): boll
+ * @method static iteration(bool $mayBlock): bool
  */
 class MainContext
 {


### PR DESCRIPTION
Method is static, takes mayBlock as a parameter (as per https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/method.html the name was required), and the return type is typod. 